### PR TITLE
README.rst: update link to dvwa

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -257,6 +257,6 @@ TBA
 
 
 
-.. _`dvwa`: http://dvwa.co.uk
+.. _`dvwa`: https://github.com/digininja/DVWA
 .. _`bobby-tables xkcd comics`: https://xkcd.com/327/
 .. _`Web vulnerabilities`: https://www.slideshare.net/OlexandrKovalchuk/web-vulnerabilities-78366279


### PR DESCRIPTION
dvwa.co.uk does not host dvwa anymore